### PR TITLE
Suite run settings and autoparallel mode customizations

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -6,8 +6,8 @@
     "sailormoon/flags": {
         "@": ":4fe826161e0dcb093278126ae08b0b2cbab0e2f7"
     },
-    "eidheim/tiny-process-library": {
-        "@": ":5bc47531a97f80ac07092ac3ed56a26139c748b3",
+    "GerHobbelt/tiny-process-library": {
+        "@": ":2f7b3cf6d9972d096a77863e31c854f80194927d",
         "x:windows": ["test/", "example.cpp", "process_unix.cpp"],
         "x:windows-cxx17": ["test/", "example.cpp", "process_unix.cpp"],
         "x:vs-16-2019-win64-cxx17": ["test/", "example.cpp", "process_unix.cpp"],

--- a/.tipi/opts
+++ b/.tipi/opts
@@ -1,0 +1,5 @@
+IF (WIN32)
+  add_compile_definitions(NOMINMAX) 
+ENDIF()
+
+add_compile_definitions(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES) 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,119 @@ runner.register_suite(suite_8, "Suite 10",  ext_run_setting::after_all,   false)
 runner.register_suite(suite_9, "Suite 11",  ext_run_setting::after_all,   true);
 ```
 
+Controlling auto-parallel child process parameters and environment
+------------------------------------------------------------------
+
+**cute_ext** launches one process per test unit in `--parallel` mode. In order to enable customizations to the start parameters and environment variables
+presented to each of these child processes you can register a callback that enables modifying startup parameters:
+
+```cpp
+runner.set_on_before_autoparallel_child_process([](const auto& suite_name, const auto& unit_name, auto& args, auto& env) -> void {
+  /**
+   * suite_name and unit_name are the std::string values used during the registration of the suites/units
+   */
+
+  /**
+   * args is the pre-populated command + arguments vector that is used to start the child process
+   * 
+   * /!\ each parameter should be inserted into its own entry
+   */
+
+  /**
+   * env in an std::unsorted_map<std::string, std::string> that contains a copy of the environment that 
+   * was presented to the currently running executable
+   */
+
+  /**
+   * EXAMPLES:
+   */
+  
+  // add CUSTOM_VARIABLE=42 to env
+  env.emplace("CUSTOM_VARIABLE", "42");
+  
+  // add --custom-option VALUE to command line arguments
+  args.push_back("--custom-option");
+  args.push_back("VALUE");
+});
+```
+
+As a concrete example, to enable generating a per-process `gcov` report:
+
+```cpp
+
+#include <filesystem>
+
+#if defined(_WIN32)
+
+#include <windows.h>
+#include <processthreadsapi.h>
+
+#else
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#endif
+
+
+auto get_pid = []() -> size_t {
+  #if defined(_WIN32)
+
+  return ::GetCurrentProcessId();
+
+  #else
+
+  return getpid(void);
+
+  #endif
+};
+
+auto clean_path = [](std::string path) {
+  static std::string forbidden_path_chars( "!$%&()[]{}§*+#:?\"<>|" );
+  std::transform(
+    path.begin(), path.end(), path.begin(), 
+    [&](char c) { return forbidden_path_chars.find(c) != std::string::npos ? '_' : c; }
+  );
+
+  return path;
+};
+
+auto current_pid = get_pid();
+
+std::stringstream pathbase_ss{};
+
+#if defined(_WIN32)
+pathbase_ss << "C:/temp/"; 
+#else
+pathbase_ss << "/tmp/"; 
+#endif
+
+pathbase_ss << "cute_ext_cov_" << current_pid << "/";
+std::string pathbase = pathbase_ss.str();
+std::filesystem::create_directories(pathbase);
+
+std::cout << "\n---\n" << "ℹ️ All coverage analysis files will be written to: " << pathbase << "\n---\n" << std::endl;
+
+runner.set_on_before_autoparallel_child_process([&, pathbase](const auto& suite_name, const auto& unit_name, auto& args, auto& env) -> void {
+    // place all the .gcda files as: /tmp/cute_ext_cov_{current_pid}/{suite_name}-{unit_name}/<gcov-generate-filename.gcda>
+    std::stringstream path_ss{};
+    path_ss << pathbase << clean_path(suite_name) << "-" << clean_path(unit_name); 
+
+    std::string path = path_ss.str();
+    std::filesystem::create_directories(path);           
+
+    env.emplace("GCOV_PREFIX", path);  
+    env.emplace("GCOV_PREFIX_STRIP", "10000");  // clear all gcov generated folders
+});
+
+```
+
+Other helpers
+-------------
+
+```cpp
+if(!runner.is_autoparallel_child()) { /* .... */ }
+```
 
 Licence
 -------

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ auto get_pid = []() -> size_t {
 
   #else
 
-  return getpid(void);
+  return getpid();
 
   #endif
 };

--- a/include/modern_listener.hpp
+++ b/include/modern_listener.hpp
@@ -217,7 +217,7 @@ namespace tipi::cute_ext
 
         sot << "  | ";
         if(suite_ptr->count_success == suite_ptr->count_expected) { sot << termcolor::green; }
-        sot << "Pass      " << suite_ptr->count_success << "\n";
+        sot << "Pass      " << suite_ptr->count_success << termcolor::reset << "\n";
         if(suite_ptr->count_success == suite_ptr->count_expected) { sot << termcolor::reset; } 
 
         if(suite_ptr->count_failures > 0) { 

--- a/include/modern_listener.hpp
+++ b/include/modern_listener.hpp
@@ -23,11 +23,11 @@ namespace tipi::cute_ext
   protected:
     const std::string SEPARATOR_THICK = "===============================================================================\n";
     const std::string SEPARATOR_THIN  = "-------------------------------------------------------------------------------\n";
-  
 
   public:
     modern_listener(std::ostream &os = std::cerr) 
-      : parallel_listener(os) {  
+      : parallel_listener(os) 
+    {
     }
     
     ~modern_listener() {
@@ -43,16 +43,19 @@ namespace tipi::cute_ext
         std::string datetimenowstr{std::ctime(&now_tm)};
         datetimenowstr.pop_back();  // f*ck that last \n
 
+        const auto lock = this->acquirex(this->out);
         this->out << util::symbols::run_icon << "Awesome testing with " << termcolor::cyan << termcolor::bold << "tipi.build" << termcolor::reset << " + " << termcolor::yellow << "CUTE" << termcolor::reset << "\n"
             << " -> Starting test at: " << datetimenowstr << " - [" <<  now.time_since_epoch().count() << "]\n"
             << SEPARATOR_THIN
-            << "\n";
+            << std::endl;
 
       }
     }
 
     void virtual parallel_render_end() override {
       using namespace std::chrono_literals;
+
+      const auto lock = this->acquirex(this->out);
 
       if(this->render_listener_info) {
         double total_time_ms = 0;
@@ -65,6 +68,7 @@ namespace tipi::cute_ext
         auto count_suites_pass = std::count_if(this->suites.begin(), this->suites.end(), [](auto &p) { return p.second->is_success(); });
         auto count_suites_fail = std::count_if(this->suites.begin(), this->suites.end(), [](auto &p) { return p.second->is_success() == false; });  
 
+
         this->out 
           << "\n"
           << "Test stats: \n"
@@ -72,8 +76,7 @@ namespace tipi::cute_ext
           << " - suites passed:       " << count_suites_pass << "\n";
 
         if(count_suites_fail > 0) { this->out << termcolor::red; }
-        this->out << " - suites failed:       " << count_suites_fail << "\n";
-        if(count_suites_fail > 0) { this->out << termcolor::reset; }
+        this->out << " - suites failed:       " << count_suites_fail << termcolor::reset << "\n";
 
         this->out 
           << " - test cases executed: " << this->tests.size() << "\n"
@@ -100,27 +103,29 @@ namespace tipi::cute_ext
     }
 
     virtual void parallel_render_test_case_start(const std::shared_ptr<test_run> &unit) override {
-      auto &tco = (this->render_immediate_mode) ? this->out : unit->out;
-
       if(this->render_immediate_mode) {
-        parallel_render_test_case_header(tco, unit);
+        const auto lock = this->acquirex(this->out);
+        parallel_render_test_case_header(this->out, unit);
       }
     }
 
-    std::string print_line_prefix(std::istream& input, std::string line_prefix) {
+    std::string print_line_prefix_colorize_red(std::istream& input, std::string line_prefix) {
 
       std::stringstream output{};
 
+      if(termcolor::_internal::is_colorized(this->out)) {
+        output << termcolor::colorize;
+      }      
+
       std::string line;
       while (std::getline(input, line)) {
-        output << line_prefix << line << "\n";
+        output << line_prefix << termcolor::red << line << termcolor::reset << "\n";
       }
 
       return output.str();
     }
 
     virtual void parallel_render_test_case_result(std::ostream &tco, const std::shared_ptr<test_run> &unit) override {
-
       if(unit->outcome == test_run_outcome::Pass) {
         tco << termcolor::green << util::symbols::test_pass << util::padRight(" PASS", 11, ' ') << termcolor::reset;
       }
@@ -135,46 +140,54 @@ namespace tipi::cute_ext
       }
 
       if(unit->get_test_duration().count() < 1) {
-         tco << "    (" << unit->get_test_duration().count() * 1000 << "ms)";
+        tco << "    (" << unit->get_test_duration().count() * 1000 << "ms)";
       }
       else {
         tco << "    (" << unit->get_test_duration().count() << "s)";
       }
+
+      tco << "\n";
      
       if(unit->outcome == test_run_outcome::Fail) {
-        tco << "\n"
-            << termcolor::red  
-            << print_line_prefix(unit->info, " :> ")
-            << "\n"
-            << termcolor::reset;
+        tco << print_line_prefix_colorize_red(unit->info, " :> ")
+            << termcolor::reset
+            << "\n";
       }
       else if(unit->outcome == test_run_outcome::Error) {
-        tco << "\n"
-            << termcolor::red 
-            << print_line_prefix(unit->info, " :> ")
-            << "\n"
-            << termcolor::reset;
+        tco << print_line_prefix_colorize_red(unit->info, " :> ")
+            << termcolor::reset
+            << "\n";
       }
-      else {
-        tco << "\n";
-      }
-    
     }
 
     virtual void parallel_render_test_case_end(const std::shared_ptr<test_run> &unit) override {
 
-      auto &tco = (this->render_immediate_mode) ? this->out : unit->out;
+      if(this->render_immediate_mode) {
+        const auto lock = this->acquirex(this->out);
+        auto &tco = this->out;
 
-      if(this->render_test_info) {
-        if(!this->render_immediate_mode) {
-          parallel_render_test_case_header(tco, unit);
+        if(this->render_test_info) {
+          parallel_render_test_case_result(tco, unit);
+        }
+        else {
+          tco << unit->info.str();
         }
 
-        parallel_render_test_case_result(tco, unit);        
+        tco << std::flush;
       }
       else {
-        tco << unit->info.str();
-      } 
+        const auto lock = this->acquirex(unit->out);
+        auto &tco = unit->out;
+
+        if(this->render_test_info) {
+          parallel_render_test_case_header(tco, unit);          
+          parallel_render_test_case_result(tco, unit);
+        }
+        else {
+          //const auto lock_unit = this->acquirex();
+          tco << unit->info.str();
+        }
+      }     
     }
 
     virtual void parallel_render_suite_header(std::ostream &sot, const std::shared_ptr<suite_run> &suite_ptr) override {

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -484,7 +484,6 @@ namespace tipi::cute_ext {
       
       auto next_task_it = [&]() {        
         if(linear_mode) {
-          //std::cout << "Getting linear mode test" << std::endl;
           return std::find_if(tasks.begin(), tasks.end(), [&](auto &t) { return t.was_started() == false && t.get_suite_name() == linear_mode_suite_name; });
         }
         else {
@@ -624,8 +623,6 @@ namespace tipi::cute_ext {
       auto start_next = [&]() {
         auto nextit = next_task_it();
 
-        std::cout << "start_next()" << linear_mode << std::endl;
-
         if(nextit != tasks.end()) {
 
           const std::string& suite_name = nextit->get_suite_name();
@@ -644,8 +641,7 @@ namespace tipi::cute_ext {
             if(linear_mode == false) {
               // wait for all running tasks to finish...
               while(tests_running > 0) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));  // TODO: 1 or 10ms          
-                std::cout << "Print" << std::endl;
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));  // TODO: 1 or 10ms
               }
 
               print_finished_suites();
@@ -661,7 +657,8 @@ namespace tipi::cute_ext {
           tests_running++;
           mark_suite_started(suite_name);
 
-          nextit->start([&](const auto &task) {
+          /**note: CLANG requires us to copy capture unit_force_linear_mode (probably because of a thread locality specific behavior) */
+          nextit->start([&, unit_force_linear_mode](const auto &task) {
 
             auto urr = task.get_run_unit_result();            
 
@@ -742,7 +739,7 @@ namespace tipi::cute_ext {
           print_finished_suites();
         }
 
-        //std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        //std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
 
       if(force_destructor_exit_code.value_or(0) == 0) { 

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -853,7 +853,7 @@ namespace tipi::cute_ext {
       else {        
         // in single-TC mode (as parallel mode child process) we skip every suite that is not the
         // expected one
-        if(opt.parallel_child_run && name == opt.auto_concurrent_suite) {
+        if(!opt.parallel_run || (opt.parallel_child_run && name == opt.auto_concurrent_suite)) {
 
           all_suites_ = std::unordered_map<std::string, std::shared_ptr<ext_suite>>{
             { name, suite_ptr }

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -895,6 +895,12 @@ namespace tipi::cute_ext {
     void set_on_before_autoparallel_child_process(std::function<void(const std::string&, const std::string&, std::vector<std::string>&, std::unordered_map<std::string, std::string>&)> cb) {
       on_before_start_process_ = cb;
     }
+
+    /// @brief Returns true if the passed args signify this runner is executing in autoparallel_child mode
+    /// @return 
+    bool is_autoparallel_child() {
+      return opt.parallel_child_run;
+    }
     
     /// @brief Register a new suite and - depending on CLI arguments - run the suite immediately
     /// @param suite cute::suite

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <cute/cute_listener.h>
+#include <stdlib.h>
 
 #if defined(_WIN32)
 #include <winsock.h>
@@ -12,10 +13,16 @@
 // and vt100 support enable api on windows
 #include <windows.h>
 #include <VersionHelpers.h>
+
+#else
+// access POSIX environment
+extern char **environ;
 #endif
+
 
 namespace tipi::cute_ext::util
 {
+  using namespace std::string_literals;
 
   namespace symbols {
     #ifdef CUTEEXT_SAFE_SYMBOLS
@@ -181,4 +188,121 @@ namespace tipi::cute_ext::util
       return *this;
     }
   };
+
+  /// @brief Get the ENV variable map of THIS process
+  /// @return 
+  inline std::unordered_map<std::string, std::string> get_current_ENVIRONMENT() {
+    std::unordered_map<std::string, std::string> result{};
+    
+    #if defined(_WIN32)
+
+    auto free = [](char* p) { FreeEnvironmentStrings(p); };
+    auto env_block = std::unique_ptr<char, decltype(free)>{ GetEnvironmentStrings(), free};
+    char* env = env_block.get();
+
+    if (env != 0)
+    {
+      // GetEnvironmentStrings returns a block of \0 terminated string, with each string
+      // being formated like:
+      // VARIABLE=value\0
+      // 
+      // the last entry is terminated by two \0 (one for the variable, one for the entire block)
+      //
+      // this means that to parse through this we need to look out for two separators
+      //
+      // '=' separating the variable name from the value
+      // '\0' terminating each entry
+      //
+      // We need to keep track of these special things however (which we should skip btw...)
+      // 
+      // =C:=C:\.tipi\v7.w\40999a5-cute_ext.b\63dea0c\bin\test
+      // =D:=D:/
+      //
+      // these are "special" environment variables that cmd uses to keep track of a bunch of "special things"
+      // like per disk CWDs or expected exit codes and that are basically MSDOS compat remainders:
+      // interesting read: https://devblogs.microsoft.com/oldnewthing/20100506-00/?p=14133
+
+      int entry_start = 0;          // position of the start of variable name
+      int entry_separator = 0;      // position of the '=' separator 
+      bool search_value = false;    // toggle between looking up a VAR or VALUE
+      bool entry_line_start = true;
+      bool entry_is_msdos_special = false;
+
+      for(size_t ix = 0; ; ix++) {    
+
+        /** handle the "MSDOS special" entries that have entries starting with = */
+
+        if(entry_line_start) {
+          if(env[ix] == '=') {
+            entry_is_msdos_special = true;
+          }
+
+          entry_line_start = false;
+        }
+
+        if(entry_is_msdos_special) {
+          if(env[ix] == '\0') {
+            entry_line_start = true;
+            entry_is_msdos_special = false;
+            entry_start = ix;
+
+            // the unlikely case that we have only special entries...
+            //
+            // break on double \0 -- this is safe only because windows
+            // guarantees us that there *will be* two \0 at the end of the 
+            // env var block
+            if (env[ix + 1] == '\0') {
+              break;
+            }
+          }
+        }
+        else {
+
+          /** The "normal entries... "*/
+          if(!search_value && env[ix] == '=') {
+            search_value = true;
+            entry_separator = ix;
+          }
+          else if(env[ix] == '\0') {
+
+            std::string env_key(env + entry_start + 1, entry_separator - entry_start - 1);
+            std::string env_val(env + entry_separator + 1, ix - entry_separator - 1);
+
+            result.emplace(env_key, env_val); 
+            
+            // remember for the next round
+            search_value = false;
+            entry_start = ix;
+
+            // break on double \0 -- this is safe only because windows
+            // guarantees us that there *will be* two \0 at the end of the 
+            // env var block
+            if (env[ix + 1] == '\0') {
+              break;
+            }
+          }
+        }
+      }
+    }
+    else
+    {
+      size_t err = GetLastError();
+      throw std::runtime_error("Getting environment variables failed with return code: "s + std::to_string(err));
+    }
+
+    #else
+    char ** env;    
+    env = environ;
+    
+    for (; *env; ++env) {
+      std::string env_raw = std::string(*env);
+      auto pos_eq = env_raw.find('=');
+      result.emplace(env_raw.substr(0, pos_eq), env_raw.substr(pos_eq + 1, env_raw.size()));
+    }
+            
+    #endif
+
+    return result;
+  }
+
 }

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -16,7 +16,7 @@
 
 #else
 // access POSIX environment
-extern char **environ;
+extern "C" char **environ;
 #endif
 
 

--- a/test/extern_testsuite.cpp
+++ b/test/extern_testsuite.cpp
@@ -16,7 +16,7 @@ public:
 
   void Test3_throws()
   {
-    int f = std::stoi("ABBA");  // Throws: no conversion
+    int f = std::stoi("ABBA");  // Throws: no conversion    
   }
 };
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -61,7 +61,7 @@ public:
     }
 
     int anotherTest(){
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        //std::this_thread::sleep_for(std::chrono::milliseconds(50));
         ASSERT_EQUAL(42, 42);
         return 0;
     }
@@ -132,7 +132,7 @@ void testfn(int argc, const char **argv) {
             #if defined(_WIN32)
             return ::GetCurrentProcessId();
             #else
-            return getpid(void);
+            return getpid();
             #endif
         };
 
@@ -219,7 +219,7 @@ void testfn(int argc, const char **argv) {
 
 
     cute::suite s3{};
-    for(size_t i = 0; i <= 50; i++) {
+    for(size_t i = 0; i <= 200; i++) {
         std::string ctx = "s3_"s + std::to_string(i);
         s3 += TIPI_CUTE_SMEMFUN(OutTests, anotherTest, ctx.c_str());
     }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -110,6 +110,16 @@ void testfn(int argc, const char **argv) {
     //ynull_listener lis{};
 	
     auto runner = tipi::cute_ext::makeRunner(lis, argc, argv);
+    
+    std::atomic<size_t> counter = 0;
+    runner.set_on_before_autoparallel_child_process([&](const auto& suitename, const auto& unitname, auto& args, auto& env) {
+        std::stringstream ss{};
+
+        ss << "DATA: " << suitename << " - " << unitname << " - counter: " << counter++;
+        
+        
+        env.emplace("TEST_VARIABLE", ss.str());
+    });
 
     cute::suite s1{};
     s1.push_back(TIPI_CUTE_SMEMFUN(OutTests, mySimpleTest, "s1_1"));
@@ -164,6 +174,13 @@ void testfn(int argc, const char **argv) {
 }
 
 int main(int argc, const char **argv) {
+
+    auto r = std::getenv("TEST_VARIABLE");
+
+    if(r) {
+        std::cout << "GOT TEST_VARIABLE=" << r << std::endl;
+    }
+
     testfn(argc, argv);
     return 0;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -31,13 +31,18 @@ public:
         ASSERT_EQUAL(42, lifeTheUniverseAndEverything);
     }
 
+    void mySimpleTestLong(){        
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        ASSERT_EQUAL(42, lifeTheUniverseAndEverything);
+    }
+
     void failingtest(){
         ASSERT_EQUAL(42, 1);
     }
 
     
     void throwingtest(){
-        std::cout << "Hallo EH TDG" << std::endl;  
+        std::cout << "Hallo EH TDG ]]> blub " << std::endl;  
         throw std::runtime_error("Blah!");
     }
 
@@ -49,12 +54,14 @@ public:
 
 };
 
-cute::suite make_suite_ReadOnlyIniFileTest()
+tipi::cute_ext::ext_suite make_suite_ReadOnlyIniFileTest()
 {
-    cute::suite s {};
+    tipi::cute_ext::ext_suite s{};
+    s.run_setting = tipi::cute_ext::ext_run_setting::before_all;
     s.push_back(TIPI_CUTE_SMEMFUN(OutTests, mySimpleTest, "temp_0"));
     s.push_back(TIPI_CUTE_SMEMFUN(OutTests, mySimpleTest, "temp_1"));
     s.push_back(TIPI_CUTE_SMEMFUN(OutTests, mySimpleTest, "temp_2"));
+    s.push_back(TIPI_CUTE_SMEMFUN(OutTests, mySimpleTestLong, "temp_LONG2"));
     return s;
 }
 
@@ -90,10 +97,10 @@ size_t ynull_listener::cnt = 0;
 
 using namespace std::string_literals;
 
-int main(int argc, const char **argv) {
+void testfn(int argc, const char **argv) {
     tipi::cute_ext::util::enable_vt100_support_windows10();    
 
-    cute::xml_file_opener xmlfile(argc, argv);
+    //cute::xml_file_opener xmlfile(argc, argv);
     //tipi::cute_ext::modern_xml_listener < tipi::cute_ext::modern_listener<> > lis{xmlfile.out};    
     tipi::cute_ext::modern_listener lis{};
     //tipi::cute_ext::modern_xml_listener lis{};
@@ -132,18 +139,20 @@ int main(int argc, const char **argv) {
 
 
     cute::suite s3{};
-    for(size_t i = 0; i < 200; i++) {
+    for(size_t i = 0; i <= 50; i++) {
         std::string ctx = "s3_"s + std::to_string(i);
         s3 += TIPI_CUTE_SMEMFUN(OutTests, anotherTest, ctx.c_str());
     }
 
     s3 += TIPI_CUTE_SMEMFUN(OutTests, throwingtest, "s3_201");
     
-    runner(s1, "Suite 1");
-    runner(s2, "Suite 2");
+    runner(s2, "Linear Suite AFTER_ALL", tipi::cute_ext::ext_run_setting::after_all, true);
     runner(s3, "Suite 3");
+    runner(make_suite(), "LINEAR External suite ", tipi::cute_ext::ext_run_setting::normal, true);  
     runner(make_suite_ReadOnlyIniFileTest(), "Temp suite");
     runner(make_suite(), "External suite");  
+    
+    runner(s1, "Linear Suite BEFORE_ALL", tipi::cute_ext::ext_run_setting::before_all, true);
     
     /*try {
         wrapper.process_cmd();
@@ -152,8 +161,9 @@ int main(int argc, const char **argv) {
         std::cout << "Failed to run\n" << ex.what() << std::endl;
         return -1;
     }*/
+}
 
-    
-    
+int main(int argc, const char **argv) {
+    testfn(argc, argv);
     return 0;
 }


### PR DESCRIPTION
Adds:

- 🆕 ability to specify that suites run `before_all` or `after_all` other suites in autoparallel mode
- 🚀 ability to force suites to run in linear mode amidst auto-parallel runs
- 💯 ability to customize the start parameters and environment variables *per process* in the autoparallel mode (great for GCOV)
- 📖 some more documentation