### PR TITLE
File output control

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Features
 * Listing test cases `--list-testcases` / `-ltc`
 * Select the output formatter with `--listener`; valid options are: `ide`, `classic`, `classicxml`, `modern` (default), `modernxml` 
 * Select output type with `--output`; valid options are: `console` / `cout` (default), `error` / `cerr` or `<file-path>` (truncates previously existing content!)
+    - Following placeholders are available for the `<file-path>` options:
+        - `{executable}` name of the test executable, ex: for a `test.exe` specifying `--output "result-{executable}.txt` would result in `result-test.exe.txt`
+        - `{timestamp}` unix timestamp in seconds
 * `--help` / `-h` / `-?`
 * 🚀 `--parallel` mode: brute-force accelerate the test execution by rearanging the test suites to fit the maximum hardware parallelity for the executing machine
     - `--parallel` (default) run all maniac suites by spwaning child processes as deemed necessary

--- a/include/modern_xml_listener.hpp
+++ b/include/modern_xml_listener.hpp
@@ -100,6 +100,7 @@ namespace tipi::cute_ext
           << INDENT << "-->\n";
 
         this->out << "</testsuites>\n";
+        this->out << std::flush;
       }
     }
 
@@ -229,6 +230,8 @@ namespace tipi::cute_ext
             << INDENT
             << "</testcase>\n";
       }
+
+      tco << std::flush;
     }
 
     virtual void parallel_render_test_case_end(const std::shared_ptr<test_run> &unit) override {

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -985,7 +985,7 @@ namespace tipi::cute_ext {
       register_suite(std::make_shared<ext_suite>(suite, run_setting, force_linear), name); 
     }  
 
-
+    std::atomic<bool> first_run = true;
   
     bool run_suites(std::optional<std::string> suite_to_run = std::nullopt) {
 
@@ -993,6 +993,11 @@ namespace tipi::cute_ext {
 
       auto filter_unit_enabled = make_filter_fn(opt.filter_unit_value);
       auto filter_suite_enabled = make_filter_fn(opt.filter_suite_value);
+
+      if(first_run) {
+        first_run = false;
+        listener.render_preamble();        
+      }
 
       // if we are in concurrent / parallel mode, disable all funny rendering
       listener.set_render_options(

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -172,10 +172,12 @@ namespace tipi::cute_ext {
           std::cout << termcolor::colorize;
         }
         else {
-          auto nowTs = std::to_string(std::time(nullptr)); // std::string(std::asctime(std::localtime(&result)));
+          auto nowTs = std::to_string(std::time(nullptr));
+          auto execPath = std::filesystem::path(program_exe_path);
+
 
           std::map<std::string, std::string> placeholders_replacements = {
-            { "{executable}", program_exe_path },
+            { "{executable}", execPath.filename().generic_string() },
             { "{timestamp}", nowTs }
           };
 
@@ -183,7 +185,7 @@ namespace tipi::cute_ext {
 
             size_t findIx = listener_out.find(search);
 
-            if(findIx >= 0) {
+            if(findIx != std::string::npos) {
               listener_out.replace(findIx, search.length(), replace);
             }
           }

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -869,6 +869,7 @@ namespace tipi::cute_ext {
       // in linear mode we do this at the proper end
       if(!opt.parallel_run && !opt.parallel_child_run) {
         opt.get_listener().render_end();
+        opt.get_output() << std::flush;
       }
       
       if(force_destructor_exit_code.has_value()) {

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -172,6 +172,22 @@ namespace tipi::cute_ext {
           std::cout << termcolor::colorize;
         }
         else {
+          auto nowTs = std::to_string(std::time(nullptr)); // std::string(std::asctime(std::localtime(&result)));
+
+          std::map<std::string, std::string> placeholders_replacements = {
+            { "{executable}", program_exe_path },
+            { "{timestamp}", nowTs }
+          };
+
+          for(const auto& [search, replace] : placeholders_replacements) {
+
+            size_t findIx = listener_out.find(search);
+
+            if(findIx >= 0) {
+              listener_out.replace(findIx, search.length(), replace);
+            }
+          }
+
           std::filesystem::path output_path{listener_out};
           std::filesystem::create_directories(std::filesystem::absolute(output_path).parent_path());
 


### PR DESCRIPTION
Improving the `--output` parameter to make it more flexible with a `{executable}` and `{timestamp}` placeholders