### PR TITLE
Fixing multithreading issues in output generation when autoparallelization is enabled

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -14,6 +14,7 @@
         "x:clang-cxx17": ["test/", "example.cpp", "process_win.cpp"]
     },
     "ikalnytskyi/termcolor": {
-        "@": ":b3cb0f365f8435588df7a6b12a82b2ac5fc1fe95"
+        "@": ":b3cb0f365f8435588df7a6b12a82b2ac5fc1fe95",
+        "x": ["test/"]
     }
 }

--- a/include/tipi_cute_ext.hpp
+++ b/include/tipi_cute_ext.hpp
@@ -641,8 +641,10 @@ namespace tipi::cute_ext {
         return std::find(suites_printed.begin(), suites_printed.end(), suite_name) != suites_printed.end();
       };
 
+      size_t cnt_suites_to_print = std::count_if(all_suites_.begin(), all_suites_.end(), [&](const auto& s) { return filter_suite_enabled(s.first); });
+
       auto all_suites_printed = [&]() {
-        return suites_printed.size() == all_suites_.size();
+        return suites_printed.size() == cnt_suites_to_print;
       };
 
       auto print_suite = [&](const auto& suite, const std::string& suite_name) {
@@ -678,6 +680,10 @@ namespace tipi::cute_ext {
       auto print_finished_suites = [&]() {
         // collect the results until all tasks of a suite are finished
         for(const auto &[suite_name, suite_ptr] : all_suites_) {
+
+          if(!filter_suite_enabled(suite_name)) {
+            continue;
+          }
 
           if(suite_finished(suite_name) && !was_suite_printed(suite_name)) {
             print_suite(*suite_ptr, suite_name);


### PR DESCRIPTION
This PR fixes https://github.com/nxxm/nxxm-src/issues/1141

Description of the changes:

Due to data races in the previous implementation of `parallel_listener` we ended up having read/write inconsistencies of the buckets backing `unordered_map` when having concurrent read/writes happening even to unrelated data sets, resulting in lookups failing unexpectedly.

The fix mainly adds helper methods to executed locked reads to the storage of `suite_run` and `test_run` instances in `parallel_listener`. 